### PR TITLE
Surveycto

### DIFF
--- a/airbyte-integrations/connectors/source-surveycto/source_surveycto/spec.yaml
+++ b/airbyte-integrations/connectors/source-surveycto/source_surveycto/spec.yaml
@@ -4,12 +4,29 @@ connectionSpecification:
   title: Surveycto Spec
   type: object
   required:
-    - auth_token
+    - server_name
+    - username
+    - password
     - form_id
   properties:
-    auth_token:
+    server_name:
       type: string
-      description: Basic auth or base64 encoded of your "username:password"
+      title: Server Name
+      description: The name of the SurveryCTO server
+      order: 0
+    username:
+      type: string
+      title: Username
+      description: Username to authenticate into the SurveyCTO server
+      order: 1
+    password:
+      type: string
+      title: Password
+      description: Password to authenticate into the SurveyCTO server
+      airbyte_secret: true
+      order: 2
     form_id:
       type: string
+      title: Form ID
       description: Unique identifier for one of your forms
+      order: 3

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
 # Build SurveyCTO connector image
 cd airbyte-integrations/connectors/source-surveycto && docker build . -t airbyte/source-surveycto:dev
 
 # Build Commcare connector image
-cd airbyte-integrations/connectors/source-commcare && docker build . -t airbyte/source-commcare:dev
+cd ../../../airbyte-integrations/connectors/source-commcare && docker build . -t airbyte/source-commcare:dev
 
-docker compose up -d
+cd ../../../ && docker compose up -d

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,7 @@
+# Build SurveyCTO connector image
+cd airbyte-integrations/connectors/source-surveycto && docker build . -t airbyte/source-surveycto:dev
+
+# Build Commcare connector image
+cd airbyte-integrations/connectors/source-commcare && docker build . -t airbyte/source-commcare:dev
+
+docker compose up -d


### PR DESCRIPTION
# Changes in pull request:
- Made SurveyCTO server name a parameter provided by the user in the source setup form in Airbyte UI. To setup the connector now a user should provide the following:
    - Server Name
    - Username
    - Password
    - Form ID
- Added a deployment shell script `deploy.sh` to build the SurveyCTO and Commcare docker images