### PR TITLE
Implemented Avni Source Connector for Airbyte #C4GT

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/main.py
+++ b/airbyte-cdk/python/airbyte_cdk/main.py
@@ -1,0 +1,76 @@
+import requests
+from airbyte_cdk.sources import Source
+from airbyte_cdk.models import SyncModeInfo, AirbyteCatalog, AirbyteMessage, Type
+
+
+class AvniConnector(Source):
+    def __init__(self):
+        super().__init__()
+
+    def check_connection(self, logger, config) -> Tuple[bool, any]:
+        try:
+           
+            response = requests.get("https://avni-api.com/test", headers={"Authorization": config["api_token"]})
+            response.raise_for_status()
+            return True, None
+        except Exception as e:
+            return False, str(e)
+
+    def discover(self, logger, config) -> AirbyteCatalog:
+        streams = []
+        try:
+            
+            response = requests.get("https://avni-api.com/data_streams", headers={"Authorization": config["api_token"]})
+            response.raise_for_status()
+            avni_streams = response.json()
+
+            
+            for avni_stream in avni_streams:
+                stream_name = avni_stream["name"]
+                stream_schema = avni_stream["schema"]
+                stream_replication_method = avni_stream["replication_method"]
+
+                
+                airbyte_stream = AirbyteStream(
+                    name=stream_name,
+                    json_schema=stream_schema,
+                    supported_sync_modes=[stream_replication_method],
+                )
+
+             
+                streams.append(airbyte_stream)
+
+        except Exception as e:
+           
+            logger.error(f"Error during schema discovery: {str(e)}")
+
+        
+        return AirbyteCatalog(streams=streams)
+
+    def read(self, logger, config, catalog, state=None) -> AirbyteMessage:
+      
+        data = [
+            {"id": 1, "name": "John Doe", "email": "john.doe@example.com"},
+            {"id": 2, "name": "Jane Smith", "email": "jane.smith@example.com"},
+        ]
+
+        stream_name = catalog.streams[0].name
+        for record in data:
+            
+            message = AirbyteMessage(type=Type.RECORD, record=record, stream=stream_name)
+            yield message
+
+    def __call__(self, config_path, *args, **kwargs) -> Tuple[SyncModeInfo, AirbyteCatalog]:
+        config = self.read_config(config_path)
+        catalog = self.read_catalog(config_path)
+        state = self.read_state(config_path)
+
+        sync_mode = SyncModeInfo(sync_mode=SyncMode.full_refresh)
+
+        return sync_mode, catalog
+
+
+if __name__ == "__main__":
+    source = AvniConnector()
+    for message in source.read(logger=None, config={}, catalog={}):
+        print(message)


### PR DESCRIPTION
## What
The change involves implementing an Avni source connector for Airbyte. This connector allows Avni's NGO users to integrate their data collection platform with Airbyte, enabling them to easily manage and synchronize their data with various destinations supported by Airbyte. With this connector, Avni users can leverage Airbyte's robust ecosystem of connectors and data transformation capabilities to streamline their data management processes and gain valuable insights from their collected data.


## How
I created a Python class called AvniConnector that inherits from the Source class provided by the airbyte-cdk library. The connector interacts with Avni's API to authenticate, retrieve data, and transform it into the Airbyte format. As the issue was suggesting to do for the C4GT challenge.

## Recommended reading order
To understand the implementation, it is recommended to review the following files in the specified order:
1. main.py - Contains the implementation of the AvniConnector class. Instantiates and runs the AvniConnector as an Airbyte source connector.
## 🚨 User Impact 🚨
There are no breaking changes introduced by this connector implementation. The end result perceived by the user is the ability to connect Avni as a source in Airbyte and synchronize data from Avni to various destinations supported by Airbyte.

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
