### PR TITLE
import_all_cases config

### DIFF
--- a/airbyte-integrations/connectors/source-commcare/source_commcare/source.py
+++ b/airbyte-integrations/connectors/source-commcare/source_commcare/source.py
@@ -236,11 +236,12 @@ class Case(IncrementalStream):
     cursor_field = "indexed_on"
     primary_key = "id"
 
-    def __init__(self, start_date, schema, app_id, **kwargs):
+    def __init__(self, start_date, schema, app_id, import_all_cases, **kwargs):
         super().__init__(**kwargs)
         self._cursor_value = parse_datetime_with_microseconds(start_date)
         self.schema = schema
         self.last_record = None
+        self.import_all_cases = import_all_cases
 
     def get_json_schema(self):
         return self.schema
@@ -285,7 +286,9 @@ class Case(IncrementalStream):
     def read_records(self, *args, **kwargs) -> Iterable[Mapping[str, Any]]:
         for record in super().read_records(*args, **kwargs):
             self.last_record = record
-            if any(f in CommcareStream.forms for f in record["xform_ids"]):
+            if self.import_all_cases or any(
+                f in CommcareStream.forms for f in record["xform_ids"]
+            ):
                 self._cursor_value = parse_datetime_with_microseconds(
                     record[self.cursor_field]
                 )
@@ -475,9 +478,10 @@ class SourceCommcare(AbstractSource):
             streams.append(stream)
 
         stream = Case(
-            app_id=config["app_id"],
             start_date=config["start_date"],
             schema=self.base_schema(),
+            app_id=config["app_id"],
+            import_all_cases=config["import_all_cases"],
             project_space=config["project_space"],
             form_fields_to_exclude=form_fields_to_exclude,
             **args,

--- a/airbyte-integrations/connectors/source-commcare/source_commcare/spec.yaml
+++ b/airbyte-integrations/connectors/source-commcare/source_commcare/spec.yaml
@@ -51,6 +51,6 @@ connectionSpecification:
     import_all_cases:
       type: boolean
       title: Import All Cases
-      description: Import cases for all forms
+      description: Import cases from all applications
       default: false
       order: 5

--- a/airbyte-integrations/connectors/source-commcare/source_commcare/spec.yaml
+++ b/airbyte-integrations/connectors/source-commcare/source_commcare/spec.yaml
@@ -48,3 +48,9 @@ connectionSpecification:
       description: Include archived forms in the replication
       default: false
       order: 5
+    import_all_cases:
+      type: boolean
+      title: Import All Cases
+      description: Import cases for all forms
+      default: false
+      order: 5

--- a/airbyte-integrations/connectors/source-commcare/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-commcare/unit_tests/test_source.py
@@ -26,6 +26,7 @@ def config_fixture_1():
         "project_space": "project_space",
         "start_date": "2022-01-01T00:00:00Z",
         "form_fields_to_exclude": [],
+        "import_all_cases": False,
         "include_archived": False,
     }
 
@@ -39,7 +40,22 @@ def config_fixture_2():
         "project_space": "project_space",
         "start_date": "2022-01-01T00:00:00Z",
         "form_fields_to_exclude": [],
+        "import_all_cases": False,
         "include_archived": True,
+    }
+
+
+@pytest.fixture(name="config_import_all_cases")
+def config_fixture_3():
+    """import_all_cases=True config"""
+    return {
+        "api_key": "apikey",
+        "app_id": "appid",
+        "project_space": "project_space",
+        "start_date": "2022-01-01T00:00:00Z",
+        "form_fields_to_exclude": [],
+        "import_all_cases": True,
+        "include_archived": False,
     }
 
 
@@ -110,7 +126,7 @@ def test_include_archived_false(config):
     # form
     assert streams[0].name == "english_name"
     assert streams[0].xmlns == "namespace"
-    assert streams[0].include_archived == False
+    assert streams[0].include_archived is False
 
 
 def test_include_archived_true(config_include_archived):
@@ -136,7 +152,31 @@ def test_include_archived_true(config_include_archived):
     # form
     assert streams[0].name == "english_name"
     assert streams[0].xmlns == "namespace"
-    assert streams[0].include_archived == True
+    assert streams[0].include_archived is True
+
+
+def test_import_all_cases_true(config_import_all_cases):
+    """tests generate_streams with import_all_cases as True"""
+    source = SourceCommcare()
+    appdata = [
+        {
+            "modules": [
+                {
+                    "forms": [
+                        {
+                            "xmlns": "namespace",
+                            "name": {"en": "english_name"},
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+    streams = source.generate_streams({}, config_import_all_cases, appdata)
+    assert len(streams) == 2
+
+    # case
+    assert streams[1].import_all_cases is True
 
 
 def test_scrub_unwanted_fields_1():


### PR DESCRIPTION
## What
This PR adds the configuration parameter `import_all_cases`. This is an experiment to see if enabling this flag pulls cases which are missing from our SNEHA import

## How
The current logic imports a Case only if at least one of its `xform_ids` has been encountered while importing the `Form`s. This PR allows the user to override this check and import all Cases

## User Impact
The default value of this parameter is `False` and therefore no behaviour will change upon release

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
